### PR TITLE
security: bump log4net to 2.0.10 (CVE-2018-1285)

### DIFF
--- a/MagicNetworkAccess.Library/MagicNetworkAccess.Library.csproj
+++ b/MagicNetworkAccess.Library/MagicNetworkAccess.Library.csproj
@@ -44,7 +44,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+      <HintPath>..\packages\log4net.2.0.10\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Quartz, Version=2.4.1.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">

--- a/MagicNetworkAccess.Library/packages.config
+++ b/MagicNetworkAccess.Library/packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net452" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net452" />
   <package id="ElStefan.AnalyzersAndRules" version="1.1.6" targetFramework="net452" developmentDependency="true" />
-  <package id="log4net" version="2.0.5" targetFramework="net452" />
+  <package id="log4net" version="2.0.10" targetFramework="net452" />
   <package id="Quartz" version="2.4.1" targetFramework="net452" />
   <package id="RefactoringEssentials" version="4.4.0" targetFramework="net452" developmentDependency="true" />
   <package id="SonarAnalyzer.CSharp" version="1.20.1" targetFramework="net452" developmentDependency="true" />


### PR DESCRIPTION
## Summary\n- bump  to  to address CVE-2018-1285\n- update Library package + csproj hint path\n\n## Affected files\n- MagicNetworkAccess.Library/packages.config\n- MagicNetworkAccess.Library/MagicNetworkAccess.Library.csproj